### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This github repository serves as the foundation of our voice cloning module.
 
 [Real-Time-Voice-Cloning](https://github.com/CorentinJ/Real-Time-Voice-Cloning)
 
-See license [here](CogNative/backend/Real-Time-Voice-Cloning/LICENSE.md).
+See license [here](CogNative/models/Real-Time-Voice-Cloning/LICENSE.md).
 
 ## Team Members
 


### PR DESCRIPTION
Real-Time-Voice-Cloning license was linked to backend/real-time-voice-cloning but it has since moved to models/. Updated license link to fix its path.