### PR TITLE
Remove pretrained models

### DIFF
--- a/CogNative/models/Real-Time-Voice-Cloning/saved_models/default/README.md
+++ b/CogNative/models/Real-Time-Voice-Cloning/saved_models/default/README.md
@@ -1,0 +1,3 @@
+### Install [models](https://drive.google.com/drive/folders/1fipYnvRT3vayNuGvhfuX1hL0ZC4mEAfs?usp=sharing).
+
+Once installed, add the models (*.pt) to ```CogNative/CogNative/models/Real-Time-Voice-Cloning/saved_models/default```

--- a/CogNative/models/Real-Time-Voice-Cloning/saved_models/default/encoder.pt
+++ b/CogNative/models/Real-Time-Voice-Cloning/saved_models/default/encoder.pt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:39373b86598fa3da9fcddee6142382efe09777e8d37dc9c0561f41f0070f134e
-size 17090379

--- a/CogNative/models/Real-Time-Voice-Cloning/saved_models/default/synthesizer.pt
+++ b/CogNative/models/Real-Time-Voice-Cloning/saved_models/default/synthesizer.pt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c05e07428f95d0ed8755e1ef54cc8ae251300413d94ce5867a56afe39c499d94
-size 370554559

--- a/CogNative/models/Real-Time-Voice-Cloning/saved_models/default/vocoder.pt
+++ b/CogNative/models/Real-Time-Voice-Cloning/saved_models/default/vocoder.pt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1d7a6861589e927e0fbdaa5849ca022258fe2b58a20cc7bfb8fb598ccf936169
-size 53845290


### PR DESCRIPTION
Removed pretrained models because git-lfs no longer allowed them to be downloaded.