### PR TITLE
Improved issue with noise reduction volume dips.

### DIFF
--- a/CogNative/models/Real-Time-Voice-Cloning/main.py
+++ b/CogNative/models/Real-Time-Voice-Cloning/main.py
@@ -32,8 +32,13 @@ synthesizer = Synthesizer(synth_dir)
 vocoder.load_model(voc_weights)
 
 # DEFINE OUTPUT TEXT FOR VOICE CLONE
-text = input("Enter text for voice clone:\n")
-assert text[-1] == ".", f"{Fore.RED}ERROR: Punctuation missing."
+filename_txt = input(Fore.LIGHTGREEN_EX + "Enter name of input text file:\n")
+in_txt = Path(f"Clone_Tests/{filename_txt}.txt")
+assert os.path.exists(in_txt), f"{Fore.RED}ERROR: File not found."
+text_file = open(f"Clone_Tests/{filename_txt}.txt", "r")
+text_data = text_file.read()
+text_file.close()
+print(text_data)
 
 # ENCODE INPUT WAVEFORM
 filename = input(Fore.LIGHTGREEN_EX + "Enter name of input audio file:\n")
@@ -51,7 +56,7 @@ embed_wav = audio.preprocess_wav(og_wav, sampling_rate)
 embed = encoder.embed_utterance(embed_wav)
 
 with io.capture_output() as captured:
-    specs = synthesizer.synthesize_spectrograms([text], [embed])
+    specs = synthesizer.synthesize_spectrograms([text_data], [embed])
 
 # GENERATE UTTERANCE WITH VOCODER
 gen_wav = vocoder.infer_waveform(specs[0])
@@ -64,5 +69,5 @@ out_f = Path(f"Clone_Tests/{filename}_Clone.wav")
 aud.save_wav(gen_wav, out_f)
 
 rate, data = wavfile.read(f"Clone_Tests/{filename}_Clone.wav")
-reduced_noise = nr.reduce_noise(y=data, sr=rate)
+reduced_noise = nr.reduce_noise(y=data, sr=rate, prop_decrease=0.75)
 wavfile.write(f"Clone_Tests/{filename}_Clone_Post.wav", rate, reduced_noise)

--- a/CogNative/models/Real-Time-Voice-Cloning/main.py
+++ b/CogNative/models/Real-Time-Voice-Cloning/main.py
@@ -38,7 +38,6 @@ assert os.path.exists(in_txt), f"{Fore.RED}ERROR: File not found."
 text_file = open(f"Clone_Tests/{filename_txt}.txt", "r")
 text_data = text_file.read()
 text_file.close()
-print(text_data)
 
 # ENCODE INPUT WAVEFORM
 filename = input(Fore.LIGHTGREEN_EX + "Enter name of input audio file:\n")

--- a/CogNative/models/Real-Time-Voice-Cloning/main.py
+++ b/CogNative/models/Real-Time-Voice-Cloning/main.py
@@ -32,13 +32,8 @@ synthesizer = Synthesizer(synth_dir)
 vocoder.load_model(voc_weights)
 
 # DEFINE OUTPUT TEXT FOR VOICE CLONE
-filename_txt = input(Fore.LIGHTGREEN_EX + "Enter name of input text file:\n")
-in_txt = Path(f"Clone_Tests/{filename_txt}.txt")
-assert os.path.exists(in_txt), f"{Fore.RED}ERROR: File not found."
-text_file = open(f"Clone_Tests/{filename_txt}.txt", "r")
-text_data = text_file.read()
-text_file.close()
-print(text_data)
+text = input("Enter text for voice clone:\n")
+assert text[-1] == ".", f"{Fore.RED}ERROR: Punctuation missing."
 
 # ENCODE INPUT WAVEFORM
 filename = input(Fore.LIGHTGREEN_EX + "Enter name of input audio file:\n")
@@ -56,7 +51,7 @@ embed_wav = audio.preprocess_wav(og_wav, sampling_rate)
 embed = encoder.embed_utterance(embed_wav)
 
 with io.capture_output() as captured:
-    specs = synthesizer.synthesize_spectrograms([text_data], [embed])
+    specs = synthesizer.synthesize_spectrograms([text], [embed])
 
 # GENERATE UTTERANCE WITH VOCODER
 gen_wav = vocoder.infer_waveform(specs[0])


### PR DESCRIPTION
Volume dips appear to be caused by the proportion by which noise is reduced by being too high. To fix this the proportional decrease has been changed from 100% to 75%. This should sound better than the original clone output.

Changed the way in which text is input to a text file in clone_tests rather than command line text input.

A sample of the new noise reduction is in the google doc sample output folder under TCOC40_Clone_Post_pd=0.75.wav