### PR TITLE
Fixed printing bug; Fixed WindowsPath write bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
-CogNative/models/__pycache__/
+*/__pycache__/
 *.py[cod]
 *$py.class
 
@@ -111,6 +111,7 @@ ENV/
 env.bak/
 venv.bak/
 pyvenv/
+.vscode
 
 # Spyder project settings
 .spyderproject
@@ -131,8 +132,8 @@ dmypy.json
 .pyre/
 
 # Test audio
-CogNative/Clone_Tests/
 CogNative/backend/stt/examples/
+CogNative/examples/*
 
 # Saved models
 CogNative/models/RTVC/saved_models/default/

--- a/CogNative/main.py
+++ b/CogNative/main.py
@@ -10,17 +10,27 @@ v = RTVC("models/RTVC/saved_models/default")
 
 # SET INPUT AUDIO FILE PATH
 file_path = Path(input("Enter input audio file path:\n"))
-assert file_path.exists(), "ERROR: Path not found."
-assert file_path.suffix == '.wav', "ERROR: Enter an input .wav file"
+if not file_path.exists():
+    print(colorize("ERROR: Path not found.", "error"))
+    exit(1)
+if not file_path.suffix == '.wav':
+    print(colorize("ERROR: Enter an input .wav file", "error"))
+    exit(1)
 
 # ENTER TEXT
 text = input("Enter text for voice clone:\n")
-assert text[-1] == ".", "ERROR: Punctuation missing."
+if not text[-1] == ".":
+    print(colorize("ERROR: Punctuation missing.", "error"))
+    exit(1)
 
 # OUTPUT FILE PATH
 output_path = Path(input("Enter output audio path:\n"))
-assert output_path.parent.exists(), "ERROR: Directory not found."
-assert output_path.suffix == '.wav', "ERROR: Enter an output .wav file"
+if not output_path.parent.exists():
+    print(colorize("ERROR: Directory not found.", "error"))
+    exit(1)
+if not output_path.suffix == '.wav':
+    print(colorize("ERROR: Enter an output .wav file", "error"))
+    exit(1)
 
 # ENCODE (sometimes this takes time, so it is after inputs)
 v.encode_voice(file_path)

--- a/CogNative/main.py
+++ b/CogNative/main.py
@@ -3,9 +3,10 @@ from shutil import rmtree
 import wave
 
 from models.RTVC.RTVC import RTVC
+from models.RTVC.utils.printing import colorize
 
 # INITIALIZE RTVC
-#v = RTVC("models/RTVC/saved_models/default")
+v = RTVC("models/RTVC/saved_models/default")
 
 # SET INPUT AUDIO FILE PATH
 file_path = Path(input("Enter input audio file path:\n"))
@@ -38,14 +39,14 @@ if not temp_output_path.exists():
 out_paths = []
 
 # SYNTHESIZE OUTPUT AUDIO
-print('Synthesizing...')
+print(colorize('Synthesizing...', 'success'))
 for i, text in enumerate(input_subs):
-    out_path = f'{temp_output_path}/output' + str(i) + '.wav'
+    out_path = f'{str(temp_output_path)}/output' + str(i) + '.wav'
     v.synthesize(text + '.', out_path)
-    out_paths.append(out_path)
+    out_paths.append(str(out_path))
 
 # JOIN ALL SUB-AUDIO FILES INTO ONE OUTPUT .wav
-with wave.open(output_path, 'wb') as wav_out:
+with wave.open(str(output_path), 'wb') as wav_out:
     for i, wav_path in enumerate(out_paths):
         with wave.open(wav_path, 'rb') as wav_in:
             if i == 0:
@@ -54,3 +55,6 @@ with wave.open(output_path, 'wb') as wav_out:
 
 # REMOVE ALL TEMP FILES
 rmtree(temp_output_path)
+
+# PRINT SUCCESS
+print(colorize(f"Clone output to {output_path}", "success"))

--- a/CogNative/models/RTVC/RTVC.py
+++ b/CogNative/models/RTVC/RTVC.py
@@ -10,7 +10,7 @@ from .vocoder import audio as aud
 
 from pathlib import Path
 from pydub import AudioSegment
-from colorama import Fore
+from .utils.printing import colorize
 
 from scipy.io import wavfile
 import noisereduce as nr
@@ -39,9 +39,9 @@ class RTVC:
         # SET FILE PATH
         self.file_path = file_path
         in_wav = Path(self.file_path)
-        assert os.path.exists(in_wav), f"{Fore.RED}ERROR: File not found."
+        assert os.path.exists(in_wav), colorize("ERROR: File not found.", 'error')
 
-        print(Fore.LIGHTGREEN_EX + "Loading requested file...")
+        print(colorize("Loading requested file...", 'success'))
 
         # SYNTHESIZE EXPECTED OUTPUT WAVEFORM
         enc_wav = audio.preprocess_wav(in_wav)
@@ -61,8 +61,8 @@ class RTVC:
 
             # Output voice clone
             # Audio(out_wav, rate=synthesizer.sample_rate)
-            print(Fore.LIGHTGREEN_EX + "\nExporting clone to", Fore.CYAN + f"/{out_path}")
-            out_f = Path(f"./{out_path}")
+            print(colorize("\nExporting clone to", 'success'), colorize(f"/{out_path}", "path"))
+            out_f = f"./{out_path}"
             aud.save_wav(gen_wav, out_f)
 
             rate, data = wavfile.read(out_path)
@@ -82,5 +82,5 @@ if __name__ == "__main__":
         # DEFINE OUTPUT TEXT FOR VOICE CLONE
         text = input("Enter text for voice clone:\n")
 
-        print('Synthesizing...')
+        print(colorize('Synthesizing...', 'success'))
         v.synthesize(text, 'output')

--- a/CogNative/models/RTVC/RTVC.py
+++ b/CogNative/models/RTVC/RTVC.py
@@ -39,7 +39,7 @@ class RTVC:
         # SET FILE PATH
         self.file_path = file_path
         in_wav = Path(self.file_path)
-        assert os.path.exists(in_wav), colorize("ERROR: File not found.", 'error')
+        assert os.path.exists(in_wav), "ERROR: File not found."
 
         print(colorize("Loading requested file...", 'success'))
 

--- a/CogNative/models/RTVC/utils/printing.py
+++ b/CogNative/models/RTVC/utils/printing.py
@@ -1,0 +1,20 @@
+from colorama import Fore
+
+def colorize(text, type):
+    """
+    Print text in color.
+    
+    Colors:
+        success - Green\n
+        warning - Yellow\n
+        error   - Red\n
+        path    - Cyan\n
+    """
+    colors = {
+        'success': Fore.LIGHTGREEN_EX,
+        'warning': Fore.YELLOW,
+        'error': Fore.RED,
+        'path': Fore.CYAN
+    }
+    
+    return f"{colors[type]}{str(text)}{Fore.RESET}"


### PR DESCRIPTION
## Bug 1
#53 - **Bug with printing colors**, but not resetting the color back to default. For example, everything after a green print would always be green. I made a function in ```RTVC/utils``` called ```colorize``` that can be used for printing in color and not worrying about the syntax.

## Bug 2
#54 - This was just an oversight when I made my last push yesterday. I left the initialization of ```RTVC``` commented.

## Bug 3
I also realized that there was a WindowsPath error in my code. It is because I added checks to make sure that directories and files exist when the user enters file paths. This caused an issue with the ```wave``` module that writes the synthesized data to audio files. I called the wave module using strings instead of WindowsPath objects.

Closes #53 
Closes #54