### PR TITLE
Fixed paths in main.py and RTVC

### DIFF
--- a/CogNative/main.py
+++ b/CogNative/main.py
@@ -2,10 +2,10 @@ from pathlib import Path
 from shutil import rmtree
 import wave
 
-from models.RTVC.RTVC import RTVC
-from models.RTVC.utils.printing import colorize
+from .models.RTVC.RTVC import RTVC
+from .models.RTVC.utils.printing import colorize
 
-from backend.backend import speech_transcription
+from .backend.backend import speech_transcription
 
 # INITIALIZE RTVC
 lang_check = input("Clone from foreign language? (y/n)\n")
@@ -13,7 +13,7 @@ if lang_check == "y":
     src_lang = input("Enter source language:\n").lower()
 else:
     src_lang = "english"
-v = RTVC("models/RTVC/saved_models/default", src_lang)
+v = RTVC("CogNative/models/RTVC/saved_models/default", src_lang)
 
 # SET INPUT AUDIO FILE PATH
 file_path = Path(input("Enter input audio file path:\n"))

--- a/CogNative/models/RTVC/RTVC.py
+++ b/CogNative/models/RTVC/RTVC.py
@@ -81,7 +81,7 @@ class RTVC:
     def get_embedding_path(self):
         """Returns the embedding file location."""
         file_path_fmt = str(self.file_path).replace('/', ';').replace('\\', ';')
-        embedding_path = f"examples/saved_embeds/{file_path_fmt}.ckpt"
+        embedding_path = f"CogNative/examples/saved_embeds/{file_path_fmt}.ckpt"
         return embedding_path
 
     def synthesize(self, text, out_path):


### PR DESCRIPTION
This is meant to fix paths in ```main.py``` and ```RTVC``` to support running as we discussed recently:

```python -m CogNative.main```

Everything from now on should be ran this way, from the _top-level_ directory so all relative paths work properly.